### PR TITLE
alternate graphics for the 'more linkables' toolboxes

### DIFF
--- a/Patches/Linkables.xml
+++ b/Patches/Linkables.xml
@@ -164,6 +164,22 @@
 						</graphicData>
 					</value>
 				</li>
+				<!-- stick the vanilla tool cabinet texture onto the tier 1 ML cabinet 9-8-2020 -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="ToolCabinetA"]/graphicData/texPath</xpath>
+					<value>
+						<texPath>Things/Building/Misc/ToolCabinet</texPath>
+						<color>(96,114,95)</color>
+					</value>
+				</li>
+				<!-- lets do the tier 2 ML cabinet, too 9-9-2020 -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="ToolCabinetB"]/graphicData/texPath</xpath>
+					<value>
+						<texPath>Things/Building/Misc/ToolCabinet</texPath>
+						<color>(150,40,40)</color>
+					</value>
+				</li>
 				<!--Kitchen Cupboard Costs-->
 				<li Class="PatchOperationConditional">
 					<xpath>Defs/ThingDef[defName="KitchenCupboard"]/stuffCategories</xpath>


### PR DESCRIPTION
This is a separate change from my xml selector update. This is more of a 'personal preference' patch for the more linkables support, which changes the tier 1 ML toolbox(the blue one) to use the art assets for the vanilla(green) toolbox, since it is no longer being used in favor of the Gloomy one. It also makes the tier 2 toolbox(the red one) appear to be a brighter shade of red(again, using the vanilla textures) to more closely resemble an actual IRL red mechanics toolbox.
![Capture](https://user-images.githubusercontent.com/51767311/93368701-2a826380-f803-11ea-8806-a002e3cc23e7.PNG)
